### PR TITLE
Behavioral Iterator pattern D5.5: Added SearchForRelatedQuestion() 

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,6 +36,13 @@ in such a way that makes it simple to use, without losing any of its required fu
 ![Figure 5.1](https://github.com/brandonbjs/Quiz-Creator/blob/master/Figure5.1.png)
 Design Pattern 1: (Behavioral) Template Method - FITBQuestion overrides the CorrectResponse() method in the Question class
 
+![Figure 5.2](https://github.com/brandonbjs/Quiz-Creator/blob/master/DesignPattern5.2.PNG)
+Design Pattern 2: (Behavioral) Iterator Pattern - SearchForRelatedQuestion() method iterates through the quiz class' available
+list of questions and searches the question prompts to find the first question that contains the user entered keyword. If a related
+question is found, it returns the question index, otherwise the method returns -1.
+Quiz: (https://github.com/brandonbjs/Quiz-Creator/blob/master/Quiz-Creator/Quiz.cs)
+Question: (https://github.com/brandonbjs/Quiz-Creator/blob/master/Quiz-Creator/Question.cs)
+
 ## Design Principles
 	SOLID Principles
 	-Single responsibility principle

--- a/Quiz-Creator/Quiz.cs
+++ b/Quiz-Creator/Quiz.cs
@@ -95,6 +95,33 @@ namespace Quiz_Creator
             return questions.Count;
         }
 
+        /// <summary>
+        /// searchForRelatedQuestion is intended to iterate through our 
+        /// available list of questions and search for a user entered keyword
+        /// in each question prompt.If the keyword is found, the method 
+        /// returns the question index, otherwise it returns -1. This first method
+        /// implementation is only able to find the FIRST question in the list with
+        /// the corresponding keyword.
+        /// </summary>
+        /// <param name="keyword"> string variable that holds the user entered
+        /// keyword we are searching for in our question prompts.</param>
+        /// <returns>An integer variable representing the index of the question
+        /// our keyword was found in. If no such keyword is found in our questions,
+        /// return -1.</returns>
+        public int SearchForRelatedQuestion(string keyword)
+        {
+            int counter = 0;
+            foreach (var q in questions)
+            {
+                if ( q.Prompt.Contains(keyword) )
+                {
+                    return counter;
+                }
+                counter++;
+            }
+            return -1;
+        }
+
         #endregion
 
         #region Responses


### PR DESCRIPTION
Added a SearchForRelatedQuestion() method in the Quiz class that iterates through available questions and searches prompts using a user entered keyword. Returns question index if keyword is found, otherwise returns -1. This initial method implementation only finds the FIRST question with the corresponding keyword search. Any subsequent question that might also have a prompt utilizing the user entered keyword will not be found. This is mean't to be fixed in future implementations.

As for right now, this satisfies the Behavioral Iterator pattern and can be used as a subsection for D5.5. 
My branch DESIGN.md deliverable has been updated to reflect this Design Pattern and the master branch will be updated once this pull request is merged.